### PR TITLE
Add PlatformIO alias for HELTEC_V4 (WIFI_LORA_32_V4) in headers

### DIFF
--- a/src/LoRaWan_APP.h
+++ b/src/LoRaWan_APP.h
@@ -4,6 +4,12 @@
 #ifndef LoRaWan_APP_H
 #define LoRaWan_APP_H
 #include "Arduino.h"
+
+/* PlatformIO compatibility alias for Heltec WiFi LoRa 32 V4 */
+#if defined(HELTEC_V4) && !defined(WIFI_LORA_32_V4)
+#define WIFI_LORA_32_V4
+#endif
+
 #if !defined(HT_DE01)&&!defined(WIFI_Kit_32)&&!defined(WIFI_Kit_32_V3)
 #include "ESP32_Mcu.h"
 #include <stdio.h>

--- a/src/heltec.h
+++ b/src/heltec.h
@@ -3,6 +3,11 @@
 #ifndef _HELTEC_H_
 #define _HELTEC_H_
 
+/* PlatformIO compatibility alias for Heltec WiFi LoRa 32 V4 */
+#if defined(HELTEC_V4) && !defined(WIFI_LORA_32_V4)
+#define WIFI_LORA_32_V4
+#endif
+
 #if defined(ESP32)
 
 #include <Arduino.h>


### PR DESCRIPTION
### Motivation
- Provide PlatformIO compatibility so code that checks for `WIFI_LORA_32_V4` is also enabled when the board macro `HELTEC_V4` is defined.

### Description
- Add an alias macro in `heltec.h` and `LoRaWan_APP.h` that defines `WIFI_LORA_32_V4` when `HELTEC_V4` is present and `WIFI_LORA_32_V4` is not already defined, and restore a missing newline at EOF in `LoRaWan_APP.h`.

### Testing
- No automated tests were run for this small compatibility change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec814ebe048326b95f0caea2542c5e)